### PR TITLE
Allow assigning projects with fuzzy search on task add

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,9 +156,9 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58549f1842da3080ce63002102d5bc954c7bc843d4f47818e642abdc36253552"
+checksum = "29c39203181991a7dd4343b8005bd804e7a9a37afb8ac070e43771e8c820bbde"
 dependencies = [
  "chrono",
  "chrono-tz-build",
@@ -168,9 +168,9 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz-build"
-version = "0.0.2"
+version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db058d493fb2f65f41861bfed7e3fe6335264a9f0f92710cab5bdf01fef09069"
+checksum = "6f509c3a87b33437b05e2458750a0700e5bdd6956176773e6c7d6dd15a283a0c"
 dependencies = [
  "parse-zoneinfo",
  "phf",
@@ -179,9 +179,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.14"
+version = "3.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54635806b078b7925d6e36810b1755f2a4b5b4d57560432c1ecf60bcbe10602b"
+checksum = "44bbe24bbd31a185bc2c4f7c2abe80bea13a20d57ee4e55be70ac512bdc76417"
 dependencies = [
  "atty",
  "bitflags",
@@ -196,9 +196,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.2.7"
+version = "3.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759bf187376e1afa7b85b959e6a664a3e7a95203415dba952ad19139e798f902"
+checksum = "9ba52acd3b0a5c33aeada5cdaa3267cdc7c594a98731d4268cdc1532f4264cb4"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -342,7 +342,7 @@ checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
 
 [[package]]
 name = "doist"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -351,6 +351,7 @@ dependencies = [
  "config",
  "dialoguer",
  "dirs",
+ "fuzzy-matcher",
  "indicatif",
  "json-patch",
  "lazy_static",
@@ -690,9 +691,9 @@ checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 
 [[package]]
 name = "js-sys"
-version = "0.3.58"
+version = "0.3.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3fac17f7123a73ca62df411b1bf727ccc805daa070338fda671c86dac1bdc27"
+checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1014,18 +1015,18 @@ dependencies = [
 
 [[package]]
 name = "phf"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
+checksum = "4724fa946c8d1e7cd881bd3dbee63ce32fc1e9e191e35786b3dc1320a3f68131"
 dependencies = [
  "phf_shared",
 ]
 
 [[package]]
 name = "phf_codegen"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb1c3a8bc4dd4e5cfce29b44ffc14bedd2ee294559a294e2a4d4c9e9a6a13cd"
+checksum = "32ba0c43d7a1b6492b2924a62290cfd83987828af037b0743b38e6ab092aee58"
 dependencies = [
  "phf_generator",
  "phf_shared",
@@ -1033,9 +1034,9 @@ dependencies = [
 
 [[package]]
 name = "phf_generator"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
+checksum = "5b450720b6f75cfbfabc195814bd3765f337a4f9a83186f8537297cac12f6705"
 dependencies = [
  "phf_shared",
  "rand",
@@ -1043,9 +1044,9 @@ dependencies = [
 
 [[package]]
 name = "phf_shared"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+checksum = "9dd5609d4b2df87167f908a32e1b146ce309c16cf35df76bc11f440b756048e4"
 dependencies = [
  "siphasher",
  "uncased",
@@ -1101,9 +1102,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.40"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
+checksum = "c278e965f1d8cf32d6e0e96de3d3e79712178ae67986d9cf9151f51e95aac89b"
 dependencies = [
  "unicode-ident",
 ]
@@ -1149,9 +1150,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534cfe58d6a18cc17120fbf4635d53d14691c1fe4d951064df9bd326178d7d5a"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags",
 ]
@@ -1546,9 +1547,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57aec3cfa4c296db7255446efb4928a6be304b431a806216105542a67b6ca82e"
+checksum = "7a8325f63a7d4774dd041e363b2409ed1c5cbbd0f867795e661df066b2b0a581"
 dependencies = [
  "autocfg",
  "bytes",
@@ -1773,9 +1774,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c53b543413a17a202f4be280a7e5c62a1c69345f5de525ee64f8cfdbc954994"
+checksum = "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1783,13 +1784,13 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5491a68ab4500fa6b4d726bd67408630c3dbe9c4fe7bda16d5c82a1fd8c7340a"
+checksum = "662cd44805586bd52971b9586b1df85cdbbd9112e4ef4d8f41559c334dc6ac3f"
 dependencies = [
  "bumpalo",
- "lazy_static",
  "log",
+ "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -1798,9 +1799,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.31"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de9a9cec1733468a8c657e57fa2413d2ae2c0129b95e87c5b72b8ace4d13f31f"
+checksum = "fa76fb221a1f8acddf5b54ace85912606980ad661ac7a503b4570ffd3a624dad"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1810,9 +1811,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c441e177922bc58f1e12c022624b6216378e5febc2f0533e41ba443d505b80aa"
+checksum = "b260f13d3012071dfb1512849c033b1925038373aea48ced3012c09df952c602"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1820,9 +1821,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d94ac45fcf608c1f45ef53e748d35660f168490c10b23704c7779ab8f5c3048"
+checksum = "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1833,15 +1834,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a89911bd99e5f3659ec4acf9c4d93b0a90fe4a2a11f15328472058edc5261be"
+checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
 
 [[package]]
 name = "web-sys"
-version = "0.3.58"
+version = "0.3.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fed94beee57daf8dd7d51f2b15dc2bcde92d7a72304cdf662a4371008b71b90"
+checksum = "ed055ab27f941423197eb86b2035720b1a3ce40504df082cac2ecc6ed73335a1"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "doist"
 homepage = "https://github.com/chaosteil/doist"
 repository = "https://github.com/chaosteil/doist"
 authors = ["Dominykas Djacenko <chaosteil@gmail.com>"]
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 description = "doist is an unofficial command line app for interacting with the Todoist API"
 license = "MIT"
@@ -24,6 +24,7 @@ color-eyre = "0.6"
 config = { version = "0.13", features = ["toml"] }
 dialoguer = { version = "0.10", features = ["fuzzy-select"] }
 dirs = "4"
+fuzzy-matcher = "0.3.7"
 indicatif = "0.16"
 json-patch = "0.2"
 lazy_static = "1.4.0"

--- a/src/api/rest/gateway.rs
+++ b/src/api/rest/gateway.rs
@@ -128,8 +128,8 @@ impl Gateway {
     /// Returns details about a single project.
     ///
     /// * `id` - the ID as used by the Todoist API.
-    pub async fn _project(&self, id: ProjectID) -> Result<Project> {
-        self.get::<(), _>(&format!("rest/v1/project/{}", id), None)
+    pub async fn project(&self, id: ProjectID) -> Result<Project> {
+        self.get::<(), _>(&format!("rest/v1/projects/{}", id), None)
             .await
             .wrap_err("unable to get project")
     }

--- a/src/tasks/add.rs
+++ b/src/tasks/add.rs
@@ -1,9 +1,10 @@
-use color_eyre::Result;
+use color_eyre::{eyre::eyre, Result};
+use fuzzy_matcher::{skim::SkimMatcherV2, FuzzyMatcher};
 use serde::{Deserialize, Serialize};
 
 use crate::{
     api::{
-        rest::{CreateTask, Gateway, TableTask, TaskDue},
+        rest::{CreateTask, Gateway, ProjectID, TableTask, TaskDue},
         tree::Tree,
     },
     tasks::Priority,
@@ -21,21 +22,63 @@ pub struct Params {
     /// Description that has more details about the task.
     desc: Option<String>,
     /// Sets the priority on the task. The higher the priority the more urgent the task.
-    #[clap(value_enum)]
+    #[clap(value_enum, short = 'p', long = "priority")]
     priority: Option<Priority>,
+    #[clap(flatten)]
+    project: ProjectSelect,
+}
+
+#[derive(clap::Args, Debug, Serialize, Deserialize)]
+struct ProjectSelect {
+    /// Assigns the project name with the closest name, if possible. Does fuzzy matching for the
+    /// name.
+    #[clap(short = 'P', long = "project")]
+    project_name: Option<String>,
+    /// ID of the project to attach this task to. Does nothing if -P is specified.
+    #[clap(long = "project_id")]
+    project_id: Option<ProjectID>,
+}
+
+impl ProjectSelect {
+    // TODO: make this reusable by edit etc. into own module
+    // TODO: make this generic over anything that has string input and todoist ID output
+    async fn project(&self, gw: &Gateway) -> Result<Option<ProjectID>> {
+        if self.project_name.is_none() {
+            return Ok(self.project_id);
+        }
+        let input = self.project_name.as_ref().unwrap();
+        let matcher = SkimMatcherV2::default();
+        let projects = gw.projects().await?;
+        let project = projects
+            .iter()
+            .filter_map(|p| matcher.fuzzy_match(&p.name, input).map(|s| (s, p.id)))
+            .max_by(|left, right| left.0.cmp(&right.0));
+        match project {
+            Some((_, id)) => Ok(Some(id)),
+            None => Err(eyre!("no suitable project found, aborting")),
+        }
+    }
 }
 
 pub async fn add(params: Params, gw: &Gateway) -> Result<()> {
+    let project_id = params.project.project(gw).await?;
     let mut create = CreateTask {
         content: params.name,
         description: params.desc,
         priority: params.priority.map(|p| p.into()),
+        project_id,
         ..Default::default()
     };
     if let Some(due) = params.due {
         create.due = Some(TaskDue::String(due));
     }
-    let task = gw.create(&create).await?;
-    println!("created task: {}", TableTask::from_task(&Tree::new(task)));
+    let project = match project_id {
+        Some(pid) => Some(gw.project(pid).await?),
+        None => None,
+    };
+    let task = Tree::new(gw.create(&create).await?);
+    let mut table = TableTask::from_task(&task);
+    table.1 = project.as_ref();
+    println!("created task: {}", table);
     Ok(())
 }


### PR DESCRIPTION
Now you can use `doist add "something" -P Project` to assign a task easily to a project