### PR TITLE
Add long and short params where applicable

### DIFF
--- a/src/tasks/add.rs
+++ b/src/tasks/add.rs
@@ -18,9 +18,10 @@ pub struct Params {
     /// Set due with a human-readable text.
     ///
     /// Examples: "in two days" "tomorrow", "every 2 days from Monday"
-    #[clap(short = 'd')]
+    #[clap(short = 'd', long = "due")]
     due: Option<String>,
     /// Description that has more details about the task.
+    #[clap(short = 'D', long = "desc")]
     desc: Option<String>,
     /// Sets the priority on the task. The higher the priority the more urgent the task.
     #[clap(value_enum, short = 'p', long = "priority")]

--- a/src/tasks/edit.rs
+++ b/src/tasks/edit.rs
@@ -20,7 +20,7 @@ pub struct Params {
     #[clap(short = 'd', long = "due")]
     pub due: Option<String>,
     // Description of a task.
-    #[clap(long = "desc")]
+    #[clap(short = 'D', long = "desc")]
     pub desc: Option<String>,
     /// Sets the priority on the task. The lower the priority the more urgent the task.
     #[clap(value_enum, short = 'p', long = "priority")]


### PR DESCRIPTION
Due to some clap intricacies, the long name of a parameter is not set when
setting the short parameter name, so setting long parameter names explicitly for
the ones that need it.

Fixes #7.
