### PR TITLE
Allow to set sections when adding tasks.

### DIFF
--- a/src/api/rest/gateway.rs
+++ b/src/api/rest/gateway.rs
@@ -7,7 +7,9 @@ use lazy_static::lazy_static;
 use reqwest::{Client, RequestBuilder, StatusCode};
 use serde::{de::DeserializeOwned, Serialize};
 
-use super::{CreateTask, Label, Project, ProjectID, Section, Task, TaskDue, TaskID, UpdateTask};
+use super::{
+    CreateTask, Label, Project, ProjectID, Section, SectionID, Task, TaskDue, TaskID, UpdateTask,
+};
 
 /// Makes network calls to the Todoist API and returns structs that can then be worked with.
 pub struct Gateway {
@@ -132,6 +134,15 @@ impl Gateway {
         self.get::<(), _>(&format!("rest/v1/projects/{}", id), None)
             .await
             .wrap_err("unable to get project")
+    }
+
+    /// Returns details about a single section.
+    ///
+    /// * `id` - the ID as used by the Todoist API.
+    pub async fn section(&self, id: SectionID) -> Result<Section> {
+        self.get::<(), _>(&format!("rest/v1/sections/{}", id), None)
+            .await
+            .wrap_err("unable to get section")
     }
 
     /// Makes a GET request to the Todoist API with an optional query.

--- a/src/tasks/edit.rs
+++ b/src/tasks/edit.rs
@@ -14,12 +14,12 @@ use super::list::TaskOrInteractive;
 pub struct Params {
     #[clap(flatten)]
     pub task: TaskOrInteractive,
-    // Name of a task
+    /// Name of a task
     #[clap(short = 'n', long = "name")]
     pub name: Option<String>,
     #[clap(short = 'd', long = "due")]
     pub due: Option<String>,
-    // Description of a task.
+    /// Description of a task.
     #[clap(short = 'D', long = "desc")]
     pub desc: Option<String>,
     /// Sets the priority on the task. The lower the priority the more urgent the task.

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -6,5 +6,6 @@ mod fuzz_select;
 pub mod list;
 mod priority;
 mod project;
+mod section;
 
 pub use priority::*;

--- a/src/tasks/section.rs
+++ b/src/tasks/section.rs
@@ -1,0 +1,40 @@
+use super::fuzz_select::fuzz_select;
+use color_eyre::Result;
+use serde::{Deserialize, Serialize};
+
+use crate::api::rest::{Gateway, ProjectID, SectionID};
+
+/// Helper struct to get section information as command line parameter
+#[derive(clap::Args, Debug, Serialize, Deserialize)]
+pub struct SectionSelect {
+    /// Assigns the section name with the closest name, if possible. Does fuzzy matching for the
+    /// name. Can be used without project definition, but will match better if project is also
+    /// provided.
+    #[clap(short = 'S', long = "section")]
+    section_name: Option<String>,
+    /// ID of the section to attach this task to. Does nothing if -S is specified.
+    #[clap(long = "section_id")]
+    section_id: Option<SectionID>,
+}
+
+impl SectionSelect {
+    pub async fn section(
+        &self,
+        project_id: Option<ProjectID>,
+        gw: &Gateway,
+    ) -> Result<Option<SectionID>> {
+        let section_name = match &self.section_name {
+            Some(name) => name,
+            None => return Ok(self.section_id),
+        };
+        let sections = gw.sections().await?;
+        let sections = match project_id {
+            Some(project_id) => sections
+                .into_iter()
+                .filter(|s| s.project_id == project_id)
+                .collect(),
+            None => sections,
+        };
+        Ok(Some(fuzz_select(&sections, section_name)?))
+    }
+}


### PR DESCRIPTION
In addition to -P there will now also be -S which will select the section
instead of just the project. When a project is selected, then the section
selection will constrict itself to that project, but if used by itself with
enough uniqueness can assign even the project.
