### PR TITLE
Allow to add multiple labels when creating tasks.

### DIFF
--- a/src/api/rest/gateway.rs
+++ b/src/api/rest/gateway.rs
@@ -8,7 +8,8 @@ use reqwest::{Client, RequestBuilder, StatusCode};
 use serde::{de::DeserializeOwned, Serialize};
 
 use super::{
-    CreateTask, Label, Project, ProjectID, Section, SectionID, Task, TaskDue, TaskID, UpdateTask,
+    CreateTask, Label, LabelID, Project, ProjectID, Section, SectionID, Task, TaskDue, TaskID,
+    UpdateTask,
 };
 
 /// Makes network calls to the Todoist API and returns structs that can then be worked with.
@@ -143,6 +144,15 @@ impl Gateway {
         self.get::<(), _>(&format!("rest/v1/sections/{}", id), None)
             .await
             .wrap_err("unable to get section")
+    }
+
+    /// Returns details about a single label.
+    ///
+    /// * `id` - the ID as used by the Todoist API.
+    pub async fn label(&self, id: LabelID) -> Result<Label> {
+        self.get::<(), _>(&format!("rest/v1/labels/{}", id), None)
+            .await
+            .wrap_err("unable to get label")
     }
 
     /// Makes a GET request to the Todoist API with an optional query.

--- a/src/tasks/label.rs
+++ b/src/tasks/label.rs
@@ -1,0 +1,35 @@
+use super::fuzz_select::fuzz_select;
+use color_eyre::Result;
+use serde::{Deserialize, Serialize};
+
+use crate::api::rest::{Gateway, LabelID};
+
+#[derive(clap::Args, Debug, Serialize, Deserialize)]
+pub struct LabelSelect {
+    /// Assigns the label with the closest name, if possible. Does fuzzy matching for the name. Can
+    /// be used multiple times to attach more labels.
+    #[clap(short = 'L', long = "label")]
+    label_names: Option<Vec<String>>,
+    /// Assigns the label with the given ID. Can be used multiple times to attach more labels.
+    #[clap(long = "label_id")]
+    label_ids: Option<Vec<LabelID>>,
+}
+
+impl LabelSelect {
+    pub async fn labels(&self, gw: &Gateway) -> Result<Vec<LabelID>> {
+        let mut labels = self.label_ids.clone().unwrap_or_default();
+        if self.label_names.is_none() {
+            return Ok(labels.to_vec());
+        }
+        let all_labels = gw.labels().await?;
+        labels.extend(
+            self.label_names
+                .as_ref()
+                .unwrap()
+                .iter()
+                .map(|label| fuzz_select(&all_labels, label))
+                .collect::<Result<Vec<_>>>()?,
+        );
+        Ok(labels)
+    }
+}

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -3,6 +3,7 @@ pub mod add;
 pub mod close;
 pub mod edit;
 mod fuzz_select;
+mod label;
 pub mod list;
 mod priority;
 mod project;


### PR DESCRIPTION
This adds the possibility to attach multiple labels when creating tasks via the
CLI. The fuzzy matching as with the other stuff applies, and it's possible to
attach multiple labels at once.
