### PR TITLE
Force dialoguer theme for active item so it doesn't break colors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,9 +294,9 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "dialoguer"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8c8ae48e400addc32a8710c8d62d55cb84249a7d58ac4cd959daecfbaddc545"
+checksum = "a92e7e37ecef6857fdc0c0c5d42fd5b0938e46590c2183cc92dd310a6d078eb1"
 dependencies = [
  "console",
  "fuzzy-matcher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ chrono-tz = { version = "0.6", features = ["serde"] }
 clap = { version = "3", features = ["derive"] }
 color-eyre = "0.6"
 config = { version = "0.13", features = ["toml"] }
-dialoguer = { version = "0.10", features = ["fuzzy-select"] }
+dialoguer = { version = "0.10.2", features = ["fuzzy-select"] }
 dirs = "4"
 fuzzy-matcher = "0.3.7"
 indicatif = "0.16"

--- a/src/tasks/list.rs
+++ b/src/tasks/list.rs
@@ -160,12 +160,19 @@ fn get_interactive_tasks(list: &List) -> Result<Option<&Tree<Task>>> {
         .iter()
         .flat_map(Tree::flatten)
         .collect::<Vec<_>>();
-    let result = dialoguer::FuzzySelect::with_theme(&dialoguer::theme::ColorfulTheme::default())
-        .items(&items.iter().map(|t| list.table_task(t)).collect::<Vec<_>>())
-        .with_prompt("Select task")
-        .default(0)
-        .interact_opt()
-        .wrap_err("Unable to make a selection")?;
+    let result = dialoguer::FuzzySelect::with_theme(&dialoguer::theme::ColorfulTheme {
+        fuzzy_match_highlight_style: dialoguer::console::Style::new()
+            .for_stderr()
+            .yellow()
+            .bold(),
+        active_item_style: dialoguer::console::Style::new().for_stderr(),
+        ..Default::default()
+    })
+    .items(&items.iter().map(|t| list.table_task(t)).collect::<Vec<_>>())
+    .with_prompt("Select task")
+    .default(0)
+    .interact_opt()
+    .wrap_err("Unable to make a selection")?;
     Ok(result.map(|index| items[index]))
 }
 


### PR DESCRIPTION
I noticed that when updating to the latest dialoguer with the active element
theme, it does break existing colors in the selected item. This way I get the
old behavior back while perhaps contemplating a patch for dialoguer to unbreak
this.
