### PR TITLE
ALlow to create comments on tasks and projects

### DIFF
--- a/src/api/rest/comment.rs
+++ b/src/api/rest/comment.rs
@@ -8,6 +8,22 @@ use super::{ProjectID, TaskID};
 /// CommentID describes the unique ID of a [`Comment`].
 type CommentID = u64;
 
+/// ThreadID is the ID of the location where the comment is posted.
+#[derive(Debug, Serialize, Deserialize, Copy, Clone)]
+#[serde(untagged)]
+pub enum ThreadID {
+    /// The ID of the project this comment is attached to.
+    Project {
+        /// The ID of the [`super::Project`].
+        project_id: ProjectID,
+    },
+    /// The ID of the task this comment is attached to.
+    Task {
+        /// The ID of the [`super::Task`].
+        task_id: TaskID,
+    },
+}
+
 /// Comment describes a Comment from the Todoist API.
 ///
 /// Taken from the [Developer Documentation](https://developer.todoist.com/rest/v1/#comments)
@@ -15,10 +31,9 @@ type CommentID = u64;
 pub struct Comment {
     /// The unique ID of a comment.
     pub id: CommentID,
-    /// The ID of the project this comment is attached to.
-    pub project_id: Option<ProjectID>,
-    /// The ID of the task this comment is attached to.
-    pub task_id: Option<TaskID>,
+    /// Where the comment is attached to.
+    #[serde(flatten)]
+    pub thread: ThreadID,
     /// The date when the comment was posted.
     #[serde(serialize_with = "todoist_rfc3339")]
     pub posted: chrono::DateTime<chrono::Utc>,
@@ -32,6 +47,17 @@ pub struct Comment {
 /// TODO: empty for now, so it acts as a marker.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Attachment {}
+
+/// CreateComment allows to create a new comment through the API.
+#[derive(Debug, Serialize)]
+pub struct CreateComment {
+    /// The thread to attach the comment to.
+    #[serde(flatten)]
+    pub thread: ThreadID,
+    /// The text of the comment. Supports markdown.
+    pub content: String,
+    // TODO: pub attachment: Option<Attachment>,
+}
 
 /// FullComment allows to display full comment metadata when [std::fmt::Display]ing it.
 pub struct FullComment<'a>(pub &'a Comment);

--- a/src/api/rest/gateway.rs
+++ b/src/api/rest/gateway.rs
@@ -8,8 +8,8 @@ use reqwest::{Client, RequestBuilder, StatusCode};
 use serde::{de::DeserializeOwned, Serialize};
 
 use super::{
-    Comment, CreateTask, Label, LabelID, Project, ProjectID, Section, SectionID, Task, TaskDue,
-    TaskID, UpdateTask,
+    Comment, CreateComment, CreateTask, Label, LabelID, Project, ProjectID, Section, SectionID,
+    Task, TaskDue, TaskID, UpdateTask,
 };
 
 /// Makes network calls to the Todoist API and returns structs that can then be worked with.
@@ -140,6 +140,14 @@ impl Gateway {
         self.get("rest/v1/comments", Some(&[("task_id", id)]))
             .await
             .wrap_err("unable to get comments")
+    }
+
+    /// Creates a comment by calling the API.
+    pub async fn create_comment(&self, comment: &CreateComment) -> Result<Comment> {
+        self.post("rest/v1/comments", comment)
+            .await
+            .wrap_err("unable to create comment")?
+            .ok_or_else(|| eyre!("Unable to create comment"))
     }
 
     /// Returns details about a single project.

--- a/src/command.rs
+++ b/src/command.rs
@@ -2,7 +2,7 @@ use crate::{
     api::rest::Gateway,
     config::Config,
     projects,
-    tasks::{add, close, edit, list, view},
+    tasks::{add, close, comment, edit, list, view},
 };
 use clap::{Parser, Subcommand};
 use color_eyre::{eyre::eyre, Result};
@@ -48,6 +48,9 @@ enum AuthCommands {
     /// View details of a single task.
     #[clap(alias = "v")]
     View(view::Params),
+    /// Add a comment on a task.
+    #[clap(alias = "C")]
+    Comment(comment::Params),
 
     /// Manages projects.
     #[clap(subcommand, alias = "p")]
@@ -62,6 +65,9 @@ enum ProjectCommands {
     /// View details of a single project.
     #[clap(alias = "v")]
     View(projects::view::Params),
+    /// Add a comment on a project.
+    #[clap(alias = "C")]
+    Comment(projects::comment::Params),
 }
 
 impl Args {
@@ -85,9 +91,11 @@ impl Args {
                     AuthCommands::Edit(p) => edit::edit(p, &gw).await?,
                     AuthCommands::Close(p) => close::close(p, &gw).await?,
                     AuthCommands::View(p) => view::view(p, &gw).await?,
+                    AuthCommands::Comment(p) => comment::comment(p, &gw).await?,
                     AuthCommands::Projects(p) => match p {
                         ProjectCommands::List(p) => projects::list::list(p, &gw).await?,
                         ProjectCommands::View(p) => projects::view::view(p, &gw).await?,
+                        ProjectCommands::Comment(p) => projects::comment::comment(p, &gw).await?,
                     },
                 }
             }

--- a/src/projects/comment.rs
+++ b/src/projects/comment.rs
@@ -1,0 +1,26 @@
+use color_eyre::Result;
+
+use crate::api::rest::{CreateComment, FullComment, Gateway, ThreadID};
+
+use super::filter::ProjectOrInteractive;
+
+#[derive(clap::Parser, Debug)]
+pub struct Params {
+    /// The text of the comment. Supports Markdown.
+    content: String,
+    #[clap(flatten)]
+    project: ProjectOrInteractive,
+}
+
+/// Creates a new comment for a project.
+pub async fn comment(params: Params, gw: &Gateway) -> Result<()> {
+    let (id, _) = params.project.project(gw).await?;
+    let comment = gw
+        .create_comment(&CreateComment {
+            thread: ThreadID::Project { project_id: id },
+            content: params.content,
+        })
+        .await?;
+    println!("created comment: {}", FullComment(&comment));
+    Ok(())
+}

--- a/src/projects/mod.rs
+++ b/src/projects/mod.rs
@@ -1,4 +1,5 @@
 //! Controls things that work with [`crate::api::rest::Project`]s.
+pub mod comment;
 mod filter;
 pub mod list;
 pub mod view;

--- a/src/tasks/comment.rs
+++ b/src/tasks/comment.rs
@@ -1,0 +1,26 @@
+use color_eyre::Result;
+
+use crate::api::rest::{CreateComment, FullComment, Gateway, ThreadID};
+
+use super::filter::TaskOrInteractive;
+
+#[derive(clap::Parser, Debug)]
+pub struct Params {
+    /// The text of the comment. Supports Markdown.
+    content: String,
+    #[clap(flatten)]
+    task: TaskOrInteractive,
+}
+
+/// Creates a new comment for a task.
+pub async fn comment(params: Params, gw: &Gateway) -> Result<()> {
+    let (id, _) = params.task.task(gw).await?;
+    let comment = gw
+        .create_comment(&CreateComment {
+            thread: ThreadID::Task { task_id: id },
+            content: params.content,
+        })
+        .await?;
+    println!("created comment: {}", FullComment(&comment));
+    Ok(())
+}

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -1,6 +1,7 @@
 //! Controls things that work with [`crate::api::rest::Task`]s.
 pub mod add;
 pub mod close;
+pub mod comment;
 pub mod edit;
 mod filter;
 mod fuzz_select;


### PR DESCRIPTION
Adds comment creation on projects and tasks. Additionally consolidated ID
handling on comments so it's either a task or a project and never both.
