### PR TITLE
Fix undocumented colors crashing the app

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,7 +168,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
- "time",
+ "time 0.1.44",
  "wasm-bindgen",
  "winapi",
 ]
@@ -340,6 +340,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4529658bdda7fd6769b8614be250cdcfc3aeb0ee72fe66f9e41e5e5eb73eac02"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "649c91bc01e8b1eac09fb91e8dbc7d517684ca6be8ebc75bb9cafc894f9fdb6f"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfc69c5bfcbd2fc09a0f38451d2daf0e372e367986a83906d1b0dbc88134fb5"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "deadpool"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -428,6 +463,7 @@ dependencies = [
  "serde-aux",
  "serde_json",
  "serde_repr",
+ "serde_with",
  "strum",
  "thiserror",
  "tokio",
@@ -709,6 +745,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "http"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -801,6 +843,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -825,6 +873,7 @@ checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]
@@ -1023,6 +1072,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
  "libc",
 ]
 
@@ -1599,6 +1657,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89df7a26519371a3cce44fbb914c2819c84d9b897890987fa3ab096491cc0ea8"
+dependencies = [
+ "base64",
+ "chrono",
+ "hex",
+ "indexmap",
+ "serde",
+ "serde_json",
+ "serde_with_macros",
+ "time 0.3.12",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de337f322382fcdfbb21a014f7c224ee041a23785651db67b9827403178f698f"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "sha-1"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1759,6 +1845,19 @@ dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
+]
+
+[[package]]
+name = "time"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74b7cc93fc23ba97fde84f7eea56c55d1ba183f495c6715defdfc7b9cb8c870f"
+dependencies = [
+ "itoa",
+ "js-sys",
+ "libc",
+ "num_threads",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ serde = { version = "1", features = ["derive"] }
 serde-aux = "3"
 serde_json = "1"
 serde_repr = "0.1"
+serde_with = "2.0.0"
 strum = { version = "0.24", features = ["derive"] }
 thiserror = "1"
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }

--- a/src/api/rest/label.rs
+++ b/src/api/rest/label.rs
@@ -1,5 +1,6 @@
 use owo_colors::OwoColorize;
 use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, DefaultOnError};
 
 use crate::api::Color;
 
@@ -9,6 +10,7 @@ pub type LabelID = usize;
 /// Label is a tag associated with a Task. Marked with `@name` in the UI.
 ///
 /// Taken from the [Developer Documentation](https://developer.todoist.com/rest/v1/#labels).
+#[serde_as]
 #[derive(Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct Label {
     /// Unique ID of a label.
@@ -16,6 +18,7 @@ pub struct Label {
     /// Name of the label. Written as `@name` in the UI.
     pub name: String,
     /// The display color of the label as given from the API.
+    #[serde_as(deserialize_as = "DefaultOnError")]
     pub color: Color,
     /// The order among labels if we were to sort them.
     pub order: isize,
@@ -57,5 +60,14 @@ impl Label {
             order: 0,
             favorite: false,
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn succeeds_with_bad_color() {
+        let label = r#"{"id":123,"name":"hello","color":7,"order":0,"favorite":false}"#;
+        assert!(serde_json::from_str::<'_, super::Label>(label).is_ok());
     }
 }

--- a/src/api/rest/project.rs
+++ b/src/api/rest/project.rs
@@ -3,6 +3,7 @@ use crate::api::{tree::Treeable, Color};
 use owo_colors::OwoColorize;
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, DefaultOnError};
 
 /// ProjectID is the unique ID of a [`Project`]
 pub type ProjectID = u64;
@@ -12,6 +13,7 @@ pub type ProjectSyncID = u64;
 /// Project as described by the Todoist API.
 ///
 /// Taken from the [Developer Documentation](https://developer.todoist.com/rest/v1/#projects).
+#[serde_as]
 #[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
 pub struct Project {
     /// ID of the Project.
@@ -23,6 +25,7 @@ pub struct Project {
     /// How many project comments.
     pub comment_count: usize,
     /// Color as used by the Todoist UI.
+    #[serde_as(deserialize_as = "DefaultOnError")]
     pub color: Color,
     /// Whether the project is shared with someone else.
     pub shared: bool,


### PR DESCRIPTION
This allows colors to assume other numbers that were not entirely documented by
the Todoist documentation. I assume this is helpful for older projects, but will
make it also resilient for future updates. Added a small test to make sure this
case is fixed.

Fixes #24.
