### PR TITLE
Make list more powerful with more filters

### DIFF
--- a/src/tasks/fuzz_select.rs
+++ b/src/tasks/fuzz_select.rs
@@ -5,6 +5,9 @@ use fuzzy_matcher::FuzzyMatcher;
 use crate::api::rest::{Label, LabelID, Project, ProjectID, Section, SectionID, Task, TaskID};
 
 pub fn fuzz_select<U, T: FuzzSelect<U>>(items: &[T], input: &str) -> Result<U> {
+    if items.is_empty() {
+        return Err(eyre!("no items available for selection, aborting"));
+    }
     let matcher = SkimMatcherV2::default();
     let item = items
         .iter()

--- a/src/tasks/label.rs
+++ b/src/tasks/label.rs
@@ -6,11 +6,11 @@ use crate::api::rest::{Gateway, LabelID};
 
 #[derive(clap::Args, Debug, Serialize, Deserialize)]
 pub struct LabelSelect {
-    /// Assigns the label with the closest name, if possible. Does fuzzy matching for the name. Can
+    /// Uses the label with the closest name, if possible. Does fuzzy matching for the name. Can
     /// be used multiple times to attach more labels.
     #[clap(short = 'L', long = "label")]
     label_names: Option<Vec<String>>,
-    /// Assigns the label with the given ID. Can be used multiple times to attach more labels.
+    /// Uses the label with the given ID. Can be used multiple times to attach more labels.
     #[clap(long = "label_id")]
     label_ids: Option<Vec<LabelID>>,
 }

--- a/src/tasks/project.rs
+++ b/src/tasks/project.rs
@@ -1,5 +1,5 @@
 use super::fuzz_select::fuzz_select;
-use color_eyre::Result;
+use color_eyre::{eyre::WrapErr, Result};
 use serde::{Deserialize, Serialize};
 
 use crate::api::rest::{Gateway, ProjectID};
@@ -7,11 +7,10 @@ use crate::api::rest::{Gateway, ProjectID};
 /// Helper struct to get project information as command line parameter
 #[derive(clap::Args, Debug, Serialize, Deserialize)]
 pub struct ProjectSelect {
-    /// Assigns the project name with the closest name, if possible. Does fuzzy matching for the
-    /// name.
+    /// Uses the project name with the closest name, if possible. Does fuzzy matching for the name.
     #[clap(short = 'P', long = "project")]
     project_name: Option<String>,
-    /// ID of the project to attach this task to. Does nothing if -P is specified.
+    /// ID of the project to use. Does nothing if -P is specified.
     #[clap(long = "project_id")]
     project_id: Option<ProjectID>,
 }
@@ -22,6 +21,9 @@ impl ProjectSelect {
             Some(name) => name,
             None => return Ok(self.project_id),
         };
-        Ok(Some(fuzz_select(&gw.projects().await?, project_name)?))
+        Ok(Some(
+            fuzz_select(&gw.projects().await?, project_name)
+                .wrap_err("could not select project")?,
+        ))
     }
 }

--- a/src/tasks/section.rs
+++ b/src/tasks/section.rs
@@ -1,5 +1,5 @@
 use super::fuzz_select::fuzz_select;
-use color_eyre::Result;
+use color_eyre::{eyre::WrapErr, Result};
 use serde::{Deserialize, Serialize};
 
 use crate::api::rest::{Gateway, ProjectID, SectionID};
@@ -7,12 +7,11 @@ use crate::api::rest::{Gateway, ProjectID, SectionID};
 /// Helper struct to get section information as command line parameter
 #[derive(clap::Args, Debug, Serialize, Deserialize)]
 pub struct SectionSelect {
-    /// Assigns the section name with the closest name, if possible. Does fuzzy matching for the
-    /// name. Can be used without project definition, but will match better if project is also
-    /// provided.
+    /// Uses the section name with the closest name, if possible. Does fuzzy matching for the name.
+    /// Can be used without project definition, but will match better if project is also provided.
     #[clap(short = 'S', long = "section")]
     section_name: Option<String>,
-    /// ID of the section to attach this task to. Does nothing if -S is specified.
+    /// ID of the section to use. Does nothing if -S is specified.
     #[clap(long = "section_id")]
     section_id: Option<SectionID>,
 }
@@ -35,6 +34,8 @@ impl SectionSelect {
                 .collect(),
             None => sections,
         };
-        Ok(Some(fuzz_select(&sections, section_name)?))
+        Ok(Some(
+            fuzz_select(&sections, section_name).wrap_err("could not select section")?,
+        ))
     }
 }


### PR DESCRIPTION
Added the various project, section and label filters to list, so in addition to
the default todoist filters, you can use the `doist` provided fuzzy matching
filters to display the list accordingly.

Improves #25 partway.
