### PR TITLE
Implement Project filter for `projects list`

### DIFF
--- a/src/projects/list.rs
+++ b/src/projects/list.rs
@@ -1,14 +1,50 @@
+use std::collections::HashMap;
+
 use crate::api::rest::Gateway;
-use color_eyre::Result;
+use color_eyre::{eyre::eyre, Result};
 
 #[derive(clap::Parser, Debug)]
-pub struct Params {}
+pub struct Params {
+    /// If specified, will only show projects whose tasks are passing this filter.
+    #[clap(short = 'f', long = "filter")]
+    pub filter: Option<String>,
+}
 
 /// Lists available projects.
-pub async fn list(_params: Params, gw: &Gateway) -> Result<()> {
+pub async fn list(params: Params, gw: &Gateway) -> Result<()> {
+    if let Some(filter) = params.filter {
+        return show_filtered_projects(&filter, gw).await;
+    }
+    show_projects(gw).await
+}
+
+async fn show_projects(gw: &Gateway) -> Result<()> {
     let projects = gw.projects().await?;
     for project in projects.iter() {
         println!("{}", &project);
+    }
+    Ok(())
+}
+
+async fn show_filtered_projects(filter: &str, gw: &Gateway) -> Result<()> {
+    let tasks = gw.tasks(Some(filter)).await?;
+    if tasks.is_empty() {
+        return Err(eyre!("no tasks match the given filter"));
+    }
+    let hm = tasks
+        .into_iter()
+        .fold(HashMap::<_, usize>::new(), |mut hm, t| {
+            *hm.entry(t.project_id).or_default() += 1;
+            hm
+        });
+    let projects = gw
+        .projects()
+        .await?
+        .into_iter()
+        .filter(|p| hm.contains_key(&p.id))
+        .collect::<Vec<_>>();
+    for project in projects.iter() {
+        println!("{} (Tasks: {})", &project, hm[&project.id]);
     }
     Ok(())
 }

--- a/src/projects/list.rs
+++ b/src/projects/list.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::api::rest::Gateway;
+use crate::api::rest::{Gateway, Project, Task};
 use color_eyre::{eyre::eyre, Result};
 
 #[derive(clap::Parser, Debug)]
@@ -12,39 +12,67 @@ pub struct Params {
 
 /// Lists available projects.
 pub async fn list(params: Params, gw: &Gateway) -> Result<()> {
-    if let Some(filter) = params.filter {
-        return show_filtered_projects(&filter, gw).await;
-    }
-    show_projects(gw).await
-}
-
-async fn show_projects(gw: &Gateway) -> Result<()> {
     let projects = gw.projects().await?;
+    if let Some(filter) = params.filter {
+        let tasks = gw.tasks(Some(&filter)).await?;
+        if tasks.is_empty() {
+            return Err(eyre!("no tasks match the given filter"))?;
+        }
+        let projects = filtered_projects(&projects, &tasks)?;
+        for (project, tasks) in projects.iter() {
+            println!("{} (Tasks: {})", &project, tasks);
+        }
+        return Ok(());
+    }
     for project in projects.iter() {
         println!("{}", &project);
     }
     Ok(())
 }
 
-async fn show_filtered_projects(filter: &str, gw: &Gateway) -> Result<()> {
-    let tasks = gw.tasks(Some(filter)).await?;
-    if tasks.is_empty() {
-        return Err(eyre!("no tasks match the given filter"));
+fn filtered_projects<'a>(
+    projects: &'a [Project],
+    tasks: &'_ [Task],
+) -> Result<Vec<(&'a Project, usize)>> {
+    let hm = tasks.iter().fold(HashMap::<_, usize>::new(), |mut hm, t| {
+        *hm.entry(t.project_id).or_default() += 1;
+        hm
+    });
+    let projects = projects
+        .iter()
+        .filter_map(|p| hm.get(&p.id).map(|tasks| (p, *tasks)))
+        .collect();
+    Ok(projects)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::api::rest::{Project, ProjectID, Task, TaskID};
+
+    #[tokio::test]
+    async fn filter_projects() {
+        let ps = vec![
+            Project::new(1, "one"),
+            Project::new(2, "two"),
+            Project::new(3, "three"),
+        ];
+        let ts = vec![
+            create_task(1, 1, "one"),
+            create_task(2, 1, "two"),
+            create_task(3, 2, "three"),
+        ];
+        let projects = filtered_projects(&ps, &ts).unwrap();
+        assert_eq!(projects.len(), 2);
+        assert_eq!(projects[0].0.id, 1);
+        assert_eq!(projects[0].1, 2);
+        assert_eq!(projects[1].0.id, 2);
+        assert_eq!(projects[1].1, 1);
     }
-    let hm = tasks
-        .into_iter()
-        .fold(HashMap::<_, usize>::new(), |mut hm, t| {
-            *hm.entry(t.project_id).or_default() += 1;
-            hm
-        });
-    let projects = gw
-        .projects()
-        .await?
-        .into_iter()
-        .filter(|p| hm.contains_key(&p.id))
-        .collect::<Vec<_>>();
-    for project in projects.iter() {
-        println!("{} (Tasks: {})", &project, hm[&project.id]);
+
+    fn create_task(id: TaskID, project_id: ProjectID, content: &str) -> Task {
+        let mut task = crate::api::rest::Task::new(id, content);
+        task.project_id = project_id;
+        task
     }
-    Ok(())
 }


### PR DESCRIPTION
Adds a filter to `doist projects list` that then can be used to show how many
tasks a project has. If a project has 0 tasks, it is not displayed. Also added a
sneaky unit test.

Example usage is `doist projects list -f all`, but for example the regular list default of `doist projects list -f "(today | overdue)"` also works.

Fixes #25.
