### PR TITLE
Add labels list command

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -1,6 +1,6 @@
 use crate::{
     config::Config,
-    projects,
+    labels, projects,
     tasks::{add, close, comment, edit, list, view},
 };
 use clap::{AppSettings, Parser, Subcommand};
@@ -57,6 +57,9 @@ enum AuthCommands {
     /// Manages projects.
     #[clap(subcommand, alias = "p")]
     Projects(ProjectCommands),
+    /// Manages labels.
+    #[clap(subcommand, alias = "l")]
+    Labels(LabelCommands),
 }
 
 #[derive(Subcommand, Debug)]
@@ -70,6 +73,13 @@ enum ProjectCommands {
     /// Add a comment on a project.
     #[clap(alias = "C")]
     Comment(projects::comment::Params),
+}
+
+#[derive(Subcommand, Debug)]
+enum LabelCommands {
+    /// Lists all current labels
+    #[clap(alias = "l")]
+    List(labels::list::Params),
 }
 
 impl Args {
@@ -98,6 +108,9 @@ impl Args {
                             ProjectCommands::Comment(p) => {
                                 projects::comment::comment(p, &gw).await?
                             }
+                        },
+                        AuthCommands::Labels(p) => match p {
+                            LabelCommands::List(p) => labels::list::list(p, &gw).await?,
                         },
                     }
                 }

--- a/src/labels/list.rs
+++ b/src/labels/list.rs
@@ -1,0 +1,13 @@
+use crate::api::rest::Gateway;
+use color_eyre::Result;
+
+#[derive(clap::Parser, Debug)]
+pub struct Params {}
+
+pub async fn list(_params: Params, gw: &Gateway) -> Result<()> {
+    let labels = gw.labels().await?;
+    for label in labels {
+        println!("{}", &label);
+    }
+    Ok(())
+}

--- a/src/labels/mod.rs
+++ b/src/labels/mod.rs
@@ -1,0 +1,2 @@
+///! Controls things that work with [`crate::api::rest::Label`]s.
+pub mod list;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ mod command;
 mod comments;
 mod config;
 mod interactive;
+mod labels;
 mod projects;
 mod tasks;
 


### PR DESCRIPTION
Lists available labels using `doist labels list`. Will build out so labels can
be created and deleted (if possible through the API), but at least they're now
visible.
