### PR TITLE
Flatten the list if parent isn't in current filter

### DIFF
--- a/src/api/rest/project.rs
+++ b/src/api/rest/project.rs
@@ -54,6 +54,10 @@ impl Treeable for Project {
     fn parent_id(&self) -> Option<ProjectID> {
         self.parent_id
     }
+
+    fn reset_parent(&mut self) {
+        self.parent_id = None;
+    }
 }
 
 impl std::fmt::Display for Project {

--- a/src/api/rest/task.rs
+++ b/src/api/rest/task.rs
@@ -102,6 +102,10 @@ impl Treeable for Task {
     fn parent_id(&self) -> Option<TaskID> {
         self.parent_id
     }
+
+    fn reset_parent(&mut self) {
+        self.parent_id = None;
+    }
 }
 
 /// Used to display full information about a Task.


### PR DESCRIPTION
If a parent task is not included in the current todoist filter, the app will
currently crash. This will essentially ignore the parents to ensure that the
list can still be reliably displayed without crashing, at the cost of not being
able to show the subtask relationship.

This is planned to improve by fetching _all_ tasks and then showing the subset
of tasks that were fetched via the filter, but that will come later.

Fixes #38
