### PR TITLE
Renamed the vague List to State for both Tasks and Projects

### DIFF
--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -5,7 +5,7 @@ use fuzzy_matcher::FuzzyMatcher;
 use crate::api::rest::{Label, LabelID, Project, ProjectID, Section, SectionID, Task, TaskID};
 use color_eyre::{eyre::eyre, eyre::WrapErr, Result};
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Selection<T: FuzzSelect> {
     name: Option<String>,
     id: Option<T::ID>,

--- a/src/projects/mod.rs
+++ b/src/projects/mod.rs
@@ -2,6 +2,6 @@
 pub mod add;
 pub mod comment;
 pub mod delete;
-pub(crate) mod filter;
 pub mod list;
+pub(crate) mod state;
 pub mod view;

--- a/src/projects/state.rs
+++ b/src/projects/state.rs
@@ -12,17 +12,17 @@ use color_eyre::{
     Result,
 };
 
-pub struct List {
+pub struct State {
     projects: Vec<Tree<Project>>,
     sections: HashMap<SectionID, Section>,
 }
 
-impl List {
-    pub async fn fetch_tree(gw: &Gateway) -> Result<List> {
+impl State {
+    pub async fn fetch_tree(gw: &Gateway) -> Result<State> {
         let (projects, sections) = tokio::try_join!(gw.projects(), gw.sections())?;
         let projects = Tree::from_items(projects).wrap_err("projects do not form a clean tree")?;
         let sections = sections.into_iter().map(|s| (s.id, s)).collect();
-        Ok(List { projects, sections })
+        Ok(State { projects, sections })
     }
 
     pub fn _select_project(&self) -> Result<Option<&Tree<Project>>> {

--- a/src/projects/view.rs
+++ b/src/projects/view.rs
@@ -1,7 +1,7 @@
 use crate::{
     api::rest::{Gateway, Project},
     comments, interactive,
-    projects::filter::List,
+    projects::state::State,
 };
 use color_eyre::{eyre::eyre, Result};
 
@@ -15,8 +15,8 @@ pub async fn view(params: Params, gw: &Gateway) -> Result<()> {
     let projects = gw.projects().await?;
     let project = params.project.mandatory(&projects)?;
     // TODO: no refetch here
-    let list = List::fetch_tree(gw).await?;
-    let tree = list
+    let state = State::fetch_tree(gw).await?;
+    let tree = state
         .project(project.id)
         .ok_or_else(|| eyre!("full project list contained invalid data"))?;
     println!("Project: {}", &tree.item);
@@ -26,7 +26,7 @@ pub async fn view(params: Params, gw: &Gateway) -> Result<()> {
             println!("{}", project.item)
         }
     }
-    let sections = list.sections(project.id);
+    let sections = state.sections(project.id);
     if !sections.is_empty() {
         println!("Sections:");
         for section in sections {

--- a/src/tasks/filter.rs
+++ b/src/tasks/filter.rs
@@ -2,7 +2,7 @@ use color_eyre::{eyre::eyre, Result};
 
 use crate::api::rest::{Gateway, TaskID};
 
-use super::list::List;
+use super::state::State;
 
 const DEFAULT_FILTER: &str = "(today | overdue)";
 
@@ -38,16 +38,16 @@ impl TaskOrInteractive {
         Ok(id)
     }
 
-    pub async fn task(&self, gw: &Gateway) -> Result<(TaskID, List)> {
-        let list = List::fetch_tree(Some(&self.filter.filter), gw).await?;
+    pub async fn task(&self, gw: &Gateway) -> Result<(TaskID, State)> {
+        let state = State::fetch_tree(Some(&self.filter.filter), gw).await?;
         let id = match self.id {
             Some(id) => id,
-            None => list
+            None => state
                 .select_task()?
                 .map(|t| t.id)
                 .ok_or_else(|| eyre!("no task selected"))?,
         };
-        Ok((id, list))
+        Ok((id, state))
     }
 }
 

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -6,6 +6,7 @@ pub mod edit;
 mod filter;
 pub mod list;
 mod priority;
+mod state;
 pub mod view;
 
 pub use priority::*;

--- a/src/tasks/state.rs
+++ b/src/tasks/state.rs
@@ -1,0 +1,103 @@
+use std::collections::HashMap;
+
+use color_eyre::{eyre::eyre, eyre::WrapErr, Result};
+
+use crate::{
+    api::{
+        rest::{
+            FullTask, Gateway, Label, LabelID, Project, ProjectID, Section, SectionID, TableTask,
+            Task, TaskID,
+        },
+        tree::{Tree, TreeFlattenExt},
+    },
+    interactive,
+};
+
+/// State is a helper to fully construct a tasks state for display.
+pub struct State {
+    pub tasks: Vec<Tree<Task>>,
+    pub projects: HashMap<ProjectID, Project>,
+    pub sections: HashMap<SectionID, Section>,
+    pub labels: HashMap<LabelID, Label>,
+}
+
+impl State {
+    pub async fn fetch_tree(filter: Option<&str>, gw: &Gateway) -> Result<State> {
+        let (tasks, projects, sections, labels) =
+            tokio::try_join!(gw.tasks(filter), gw.projects(), gw.sections(), gw.labels())?;
+        let projects = projects.into_iter().map(|p| (p.id, p)).collect();
+        let sections = sections.into_iter().map(|p| (p.id, p)).collect();
+        let labels = labels.into_iter().map(|p| (p.id, p)).collect();
+        let tasks = Tree::from_items(tasks).wrap_err("tasks do not form clean tree")?;
+        Ok(State {
+            tasks,
+            projects,
+            sections,
+            labels,
+        })
+    }
+
+    pub fn task(&self, id: TaskID) -> Option<&Tree<Task>> {
+        self.tasks.find(id)
+    }
+
+    pub fn select_task(&self) -> Result<Option<&Tree<Task>>> {
+        if self.tasks.is_empty() {
+            return Err(eyre!("no tasks were found using the current filter"));
+        }
+        let items = self.tasks.flat_tree();
+        let result = interactive::select(
+            "Select task",
+            &items.iter().map(|t| self.table_task(t)).collect::<Vec<_>>(),
+        )?;
+        Ok(result.map(|index| items[index]))
+    }
+
+    pub fn filter<F>(self, filter: F) -> State
+    where
+        F: Fn(&Tree<Task>) -> bool,
+    {
+        let tasks: Vec<_> = self.tasks.into_iter().filter(&filter).collect();
+        State {
+            tasks,
+            projects: self.projects,
+            sections: self.sections,
+            labels: self.labels,
+        }
+    }
+
+    fn project<'a>(&'a self, task: &'a Tree<Task>) -> Option<&'a Project> {
+        self.projects.get(&task.project_id)
+    }
+
+    fn section<'a>(&'a self, task: &'a Tree<Task>) -> Option<&'a Section> {
+        task.section_id
+            .as_ref()
+            .map(|s| self.sections.get(s).unwrap())
+    }
+
+    fn labels<'a>(&'a self, task: &'a Tree<Task>) -> Vec<&'a Label> {
+        task.label_ids
+            .iter()
+            .map(|l| self.labels.get(l).unwrap())
+            .collect()
+    }
+
+    pub fn table_task<'a>(&'a self, task: &'a Tree<Task>) -> TableTask {
+        TableTask(
+            task,
+            self.project(task),
+            self.section(task),
+            self.labels(task),
+        )
+    }
+
+    pub fn full_task<'a>(&'a self, task: &'a Tree<Task>) -> FullTask {
+        FullTask(
+            task,
+            self.project(task),
+            self.section(task),
+            self.labels(task),
+        )
+    }
+}

--- a/src/tasks/view.rs
+++ b/src/tasks/view.rs
@@ -12,8 +12,8 @@ pub struct Params {
 
 /// Displays full information about a task.
 pub async fn view(params: Params, gw: &Gateway) -> Result<()> {
-    let (id, list) = params.task.task(gw).await?;
-    let task = list.full_task(list.task(id).ok_or_else(|| eyre!("no valid task"))?);
+    let (id, state) = params.task.task(gw).await?;
+    let task = state.full_task(state.task(id).ok_or_else(|| eyre!("no valid task"))?);
     println!("{}", task);
     if task.0.comment_count > 0 {
         let comments = gw.task_comments(id).await?;


### PR DESCRIPTION
This makes it a bit easier to read. In particular moved tasks::list::List to
tasks::state::State and renamed the projects::filter::List to
projects::state::State
