### PR TITLE
Add ability to add labels when editing tasks

### DIFF
--- a/src/labels/label.rs
+++ b/src/labels/label.rs
@@ -5,11 +5,10 @@ use crate::{
     interactive,
 };
 use color_eyre::{eyre::eyre, Result};
-use serde::{Deserialize, Serialize};
 
 use crate::api::rest::{Gateway, LabelID};
 
-#[derive(clap::Args, Debug, Serialize, Deserialize)]
+#[derive(clap::Args, Debug, Default)]
 pub struct LabelSelect {
     /// Uses the label with the closest name, if possible. Does fuzzy matching for the name. Can
     /// be used multiple times to use more labels.

--- a/src/tasks/edit.rs
+++ b/src/tasks/edit.rs
@@ -5,6 +5,7 @@ use crate::{
         self,
         rest::{Gateway, TaskDue, UpdateTask},
     },
+    labels::{self, LabelSelect},
     tasks::{filter::TaskOrInteractive, Priority},
 };
 
@@ -23,6 +24,8 @@ pub struct Params {
     /// Sets the priority on the task. The lower the priority the more urgent the task.
     #[clap(value_enum, short = 'p', long = "priority")]
     pub priority: Option<Priority>,
+    #[clap(flatten)]
+    pub labels: LabelSelect,
 }
 
 impl Params {
@@ -33,15 +36,28 @@ impl Params {
             due: None,
             desc: None,
             priority: None,
+            labels: LabelSelect::default(),
         }
     }
 }
 
 pub async fn edit(params: Params, gw: &Gateway) -> Result<()> {
+    let label_ids = {
+        let labels = params
+            .labels
+            .labels(gw, labels::Selection::AllowEmpty)
+            .await?;
+        if labels.is_empty() {
+            None
+        } else {
+            Some(labels.into_iter().map(|l| l.id).collect())
+        }
+    };
     let mut update = UpdateTask {
         content: params.name,
         description: params.desc,
         priority: params.priority.map(|p| p.into()),
+        label_ids,
         ..Default::default()
     };
     if let Some(due) = params.due {

--- a/src/tasks/list.rs
+++ b/src/tasks/list.rs
@@ -137,6 +137,7 @@ enum EditOptions {
     Due,
     Priority,
     // Project, TODO: allow to edit project and section when API supports it
+    // TODO: allow adding, removing labels
     Quit,
 }
 


### PR DESCRIPTION
This will allow to add labels when editing tasks through the edit command.
Should eventually make this possible through the task list, but that requires a
bit more TLC.
