### PR TITLE
Adjust coloring to disable it when requested

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1054,6 +1054,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
 
 [[package]]
+name = "is_ci"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616cde7c720bb2bb5824a224687d8f77bfd38922027f01d825cd7453be5099fb"
+
+[[package]]
 name = "itertools"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1330,6 +1336,9 @@ name = "owo-colors"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "decf7381921fea4dcb2549c5667eda59b3ec297ab7e2b5fc33eac69d2e7da87b"
+dependencies = [
+ "supports-color",
+]
 
 [[package]]
 name = "parking"
@@ -1944,6 +1953,16 @@ dependencies = [
  "quote",
  "rustversion",
  "syn",
+]
+
+[[package]]
+name = "supports-color"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4872ced36b91d47bae8a214a683fe54e7078875b399dfa251df346c9b547d1f9"
+dependencies = [
+ "atty",
+ "is_ci",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ indicatif = "0.16"
 json-patch = "0.2"
 lazy_static = "1.4.0"
 num-traits = "0.2"
-owo-colors = "3"
+owo-colors = { version = "3", features = ["supports-colors"] }
 reqwest = { version = "0.11" }
 serde = { version = "1", features = ["derive"] }
 serde-aux = "3"

--- a/src/api/rest/display.rs
+++ b/src/api/rest/display.rs
@@ -2,7 +2,7 @@ use crate::{api::tree::Tree, config::Config};
 
 use super::{Comment, DueDateFormatter, Label, Project, Section, Task};
 use chrono::Utc;
-use owo_colors::OwoColorize;
+use owo_colors::{OwoColorize, Stream};
 
 /// FullComment allows to display full comment metadata when [std::fmt::Display]ing it.
 pub struct FullComment<'a>(pub &'a Comment);
@@ -10,7 +10,13 @@ pub struct FullComment<'a>(pub &'a Comment);
 impl std::fmt::Display for FullComment<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let FullComment(comment) = self;
-        writeln!(f, "ID: {}", comment.id.bright_yellow())?;
+        writeln!(
+            f,
+            "ID: {}",
+            comment
+                .id
+                .if_supports_color(Stream::Stdout, |text| text.bright_yellow())
+        )?;
         writeln!(f, "Posted: {}", comment.posted)?;
         writeln!(
             f,
@@ -31,7 +37,14 @@ pub struct FullLabel<'a>(pub &'a Label);
 
 impl<'a> std::fmt::Display for FullLabel<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{} {}", self.0.id.bright_yellow(), self.0)
+        write!(
+            f,
+            "{} {}",
+            self.0
+                .id
+                .if_supports_color(Stream::Stdout, |text| text.bright_yellow()),
+            self.0
+        )
     }
 }
 
@@ -50,10 +63,11 @@ impl std::fmt::Display for FullTask<'_> {
         write!(
             f,
             "ID: {}\nPriority: {}\nContent: {}\nDescription: {}",
-            task.id.bright_yellow(),
+            task.id
+                .if_supports_color(Stream::Stdout, |text| text.bright_yellow()),
             task.priority,
-            task.content.default_color(),
-            task.description.default_color()
+            task.content,
+            task.description,
         )?;
         if let Some(due) = &task.due {
             write!(
@@ -113,9 +127,10 @@ impl std::fmt::Display for TableTask<'_> {
             f,
             "{}{} {} {}",
             subtask_padding,
-            task.id.bright_yellow(),
+            task.id
+                .if_supports_color(Stream::Stdout, |text| text.bright_yellow()),
             task.priority,
-            task.content.default_color(),
+            task.content,
         )?;
         if let Some(due) = &task.due {
             write!(

--- a/src/api/rest/label.rs
+++ b/src/api/rest/label.rs
@@ -1,4 +1,4 @@
-use owo_colors::OwoColorize;
+use owo_colors::{OwoColorize, Stream};
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DefaultOnError};
 
@@ -44,7 +44,9 @@ impl PartialOrd for Label {
 
 impl std::fmt::Display for Label {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        format!("@{}", self.name).bright_blue().fmt(f)
+        format!("@{}", self.name)
+            .if_supports_color(Stream::Stdout, |text| text.bright_blue())
+            .fmt(f)
     }
 }
 

--- a/src/api/rest/project.rs
+++ b/src/api/rest/project.rs
@@ -1,6 +1,6 @@
 use crate::api::deserialize::deserialize_zero_to_none;
 use crate::api::{tree::Treeable, Color};
-use owo_colors::OwoColorize;
+use owo_colors::{OwoColorize, Stream};
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DefaultOnError};
@@ -65,8 +65,9 @@ impl std::fmt::Display for Project {
         write!(
             f,
             "{} {}",
-            self.id.bright_yellow(),
-            self.name.default_color()
+            self.id
+                .if_supports_color(Stream::Stdout, |text| text.bright_yellow()),
+            self.name
         )
     }
 }

--- a/src/api/rest/section.rs
+++ b/src/api/rest/section.rs
@@ -1,4 +1,4 @@
-use owo_colors::OwoColorize;
+use owo_colors::{OwoColorize, Stream};
 use serde::{Deserialize, Serialize};
 
 use super::ProjectID;
@@ -42,8 +42,9 @@ impl std::fmt::Display for Section {
         write!(
             f,
             "{} {}",
-            self.id.bright_yellow(),
-            self.name.default_color()
+            self.id
+                .if_supports_color(Stream::Stdout, |text| text.bright_yellow()),
+            self.name
         )
     }
 }

--- a/src/api/rest/task.rs
+++ b/src/api/rest/task.rs
@@ -137,7 +137,7 @@ impl Display for Priority {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // The priority display is reversed as in the actual desktop client compared to the API.
         match self {
-            Priority::Normal => write!(f, "{}", "p4"),
+            Priority::Normal => write!(f, "p4"),
             Priority::High => write!(
                 f,
                 "{}",

--- a/src/api/rest/task.rs
+++ b/src/api/rest/task.rs
@@ -206,7 +206,11 @@ pub struct DueDateFormatter<'a>(pub &'a DueDate, pub &'a DateTime<Utc>);
 impl<'a> Display for DueDateFormatter<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.0.recurring {
-            write!(f, "🔁 ")?;
+            write!(
+                f,
+                "{}",
+                "[REPEAT] ".if_supports_color(Stream::Stdout, |_| "🔁 ")
+            )?;
         }
         if let Some(exact) = &self.0.exact {
             if exact.datetime >= *self.1 {

--- a/src/api/rest/task.rs
+++ b/src/api/rest/task.rs
@@ -4,7 +4,7 @@ use std::fmt::Display;
 use crate::api::tree::Treeable;
 use crate::api::{deserialize::deserialize_zero_to_none, serialize::todoist_rfc3339};
 use chrono::{DateTime, FixedOffset, Utc};
-use owo_colors::OwoColorize;
+use owo_colors::{OwoColorize, Stream};
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
@@ -137,10 +137,22 @@ impl Display for Priority {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // The priority display is reversed as in the actual desktop client compared to the API.
         match self {
-            Priority::Normal => write!(f, "{}", "p4".default_color()),
-            Priority::High => write!(f, "{}", "p3".blue()),
-            Priority::VeryHigh => write!(f, "{}", "p2".yellow()),
-            Priority::Urgent => write!(f, "{}", "p1".red()),
+            Priority::Normal => write!(f, "{}", "p4"),
+            Priority::High => write!(
+                f,
+                "{}",
+                "p3".if_supports_color(Stream::Stdout, |text| text.blue())
+            ),
+            Priority::VeryHigh => write!(
+                f,
+                "{}",
+                "p2".if_supports_color(Stream::Stdout, |text| text.yellow())
+            ),
+            Priority::Urgent => write!(
+                f,
+                "{}",
+                "p1".if_supports_color(Stream::Stdout, |text| text.red())
+            ),
         }
     }
 }
@@ -198,14 +210,34 @@ impl<'a> Display for DueDateFormatter<'a> {
         }
         if let Some(exact) = &self.0.exact {
             if exact.datetime >= *self.1 {
-                write!(f, "{}", exact.bright_green())
+                write!(
+                    f,
+                    "{}",
+                    exact.if_supports_color(Stream::Stdout, |text| text.bright_green())
+                )
             } else {
-                write!(f, "{}", exact.bright_red())
+                write!(
+                    f,
+                    "{}",
+                    exact.if_supports_color(Stream::Stdout, |text| text.bright_red())
+                )
             }
         } else if self.0.date >= self.1.date().naive_utc() {
-            write!(f, "{}", self.0.human_readable.bright_green())
+            write!(
+                f,
+                "{}",
+                self.0
+                    .human_readable
+                    .if_supports_color(Stream::Stdout, |text| text.bright_green())
+            )
         } else {
-            write!(f, "{}", self.0.human_readable.bright_red())
+            write!(
+                f,
+                "{}",
+                self.0
+                    .human_readable
+                    .if_supports_color(Stream::Stdout, |text| text.bright_red())
+            )
         }
     }
 }

--- a/src/tasks/close.rs
+++ b/src/tasks/close.rs
@@ -1,5 +1,5 @@
 use color_eyre::{eyre::WrapErr, Result};
-use owo_colors::OwoColorize;
+use owo_colors::{OwoColorize, Stream};
 
 use crate::{
     api::{self, rest::Gateway},
@@ -45,6 +45,9 @@ pub async fn close(params: Params, gw: &Gateway, cfg: &Config) -> Result<()> {
 
 pub async fn complete(id: api::rest::TaskID, gw: &Gateway) -> Result<()> {
     gw.complete(id).await?;
-    println!("completed task {}", id.bright_red());
+    println!(
+        "completed task {}",
+        id.if_supports_color(Stream::Stdout, |text| text.bright_red())
+    );
     Ok(())
 }

--- a/src/tasks/list.rs
+++ b/src/tasks/list.rs
@@ -32,7 +32,6 @@ pub struct Params {
 
 /// List lists the tasks of the current user accessing the gateway with the given filter.
 pub async fn list(params: Params, gw: &Gateway, cfg: &Config) -> Result<()> {
-    println!("LISTING");
     let state = if params.expand {
         State::fetch_full_tree(Some(&params.filter.filter), gw, cfg).await
     } else {


### PR DESCRIPTION
Color will only show in terminals that support it and when the environment
variable NO_COLOR is not set. This will make the output properly pipable.
