### PR TITLE
Add doist create for interactively creating a task

### DIFF
--- a/src/api/rest/task.rs
+++ b/src/api/rest/task.rs
@@ -125,11 +125,11 @@ impl PartialOrd for Task {
 pub enum Priority {
     /// p1 in the Todoist UI.
     Normal = 1,
-    /// p2 in the Todoist UI.
-    High = 2,
     /// p3 in the Todoist UI.
+    High = 2,
+    /// p2 in the Todoist UI.
     VeryHigh = 3,
-    /// p4 in the Todoist UI.
+    /// p1 in the Todoist UI.
     Urgent = 4,
 }
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -39,7 +39,7 @@ enum AuthCommands {
     #[clap(alias = "a")]
     Add(add::Params),
     /// Creates a task interactively.
-    #[clap(alias = "i")]
+    #[clap(alias = "A")]
     Create(create::Params),
     /// Lists tasks. This is the default if no subcommand is specified.
     #[clap(alias = "l")]

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,7 +1,7 @@
 use crate::{
     config::Config,
     labels, projects, sections,
-    tasks::{add, close, comment, edit, list, view},
+    tasks::{add, close, comment, create, edit, list, view},
 };
 use clap::{AppSettings, Parser, Subcommand};
 use color_eyre::Result;
@@ -38,6 +38,9 @@ enum AuthCommands {
     /// Adds a task.
     #[clap(alias = "a")]
     Add(add::Params),
+    /// Creates a task interactively.
+    #[clap(alias = "i")]
+    Create(create::Params),
     /// Lists tasks. This is the default if no subcommand is specified.
     #[clap(alias = "l")]
     List(list::Params),
@@ -126,6 +129,7 @@ impl Args {
                     let gw = cfg.gateway()?;
                     match command {
                         AuthCommands::Add(p) => add::add(p, &gw, &cfg).await?,
+                        AuthCommands::Create(p) => create::create(p, &gw, &cfg).await?,
                         AuthCommands::List(p) => list::list(p, &gw, &cfg).await?,
                         AuthCommands::Edit(p) => edit::edit(p, &gw, &cfg).await?,
                         AuthCommands::Close(p) => close::close(p, &gw, &cfg).await?,

--- a/src/tasks/add.rs
+++ b/src/tasks/add.rs
@@ -88,11 +88,13 @@ pub async fn add(params: Params, gw: &Gateway, cfg: &Config) -> Result<()> {
 
 // TODO: maybe not params? Params with default? think of project and section, due date selection
 // etc.
+// TODO: use create.rs?
 fn add_menu(params: Params) -> Result<Params> {
     let mut input = dialoguer::Input::new();
     input
         .with_prompt("Task name")
         .with_initial_text(params.name)
+        .allow_empty(false)
         .validate_with(|input: &String| -> Result<(), &str> {
             if !input.is_empty() {
                 Ok(())
@@ -101,5 +103,17 @@ fn add_menu(params: Params) -> Result<Params> {
             }
         });
     let name: String = input.interact_text().wrap_err("No input made")?;
-    Ok(Params { name, ..params })
+
+    let mut input = dialoguer::Input::new();
+    input
+        .with_prompt("Due date")
+        .allow_empty(true)
+        .with_initial_text(params.due.unwrap_or_default());
+    let due: String = input.interact_text().wrap_err("No input made")?;
+    let due = if due.is_empty() { None } else { Some(due) };
+    Ok(Params {
+        name,
+        due,
+        ..params
+    })
 }

--- a/src/tasks/add.rs
+++ b/src/tasks/add.rs
@@ -34,16 +34,9 @@ pub struct Params {
     section: interactive::Selection<Section>,
     #[clap(flatten)]
     labels: LabelSelect,
-    #[clap(short = 'i', long = "interactive")]
-    interactive: bool,
 }
 
 pub async fn add(params: Params, gw: &Gateway, cfg: &Config) -> Result<()> {
-    let params = if params.interactive {
-        add_menu(params)?
-    } else {
-        params
-    };
     let (projects, sections) = tokio::try_join!(gw.projects(), gw.sections())?;
     let project = params.project.optional(&projects)?;
     let section = params.section.optional(&sections)?;

--- a/src/tasks/create.rs
+++ b/src/tasks/create.rs
@@ -1,5 +1,6 @@
-use color_eyre::{eyre::WrapErr, Result};
+use color_eyre::{eyre::eyre, eyre::WrapErr, Result};
 use owo_colors::OwoColorize;
+use strum::EnumIter;
 
 use crate::{
     api::rest::{CreateTask, Gateway, Priority, TaskDue},
@@ -7,17 +8,96 @@ use crate::{
     interactive,
 };
 
+use super::add::create_task;
+
 #[derive(clap::Parser, Debug)]
 pub struct Params {}
 
-pub async fn create(params: Params, gw: &Gateway, cfg: &Config) -> Result<()> {
-    let (projects, sections, labels) = tokio::try_join!(gw.projects(), gw.sections(), gw.labels())?;
+#[derive(EnumIter)]
+#[repr(usize)]
+enum Selection {
+    TaskName = 0,
+    Due = 1,
+    Description = 2,
+    Priority = 3,
+}
 
-    let mut create = CreateTask::default();
+impl std::fmt::Display for Selection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Selection::TaskName => "Task Name",
+                Selection::Due => "Due",
+                Selection::Description => "Description",
+                Selection::Priority => "Priority",
+            }
+        )
+    }
+}
 
+impl From<usize> for Selection {
+    fn from(s: usize) -> Self {
+        match s {
+            0 => Selection::TaskName,
+            1 => Selection::Due,
+            2 => Selection::Description,
+            3 => Selection::Priority,
+            _ => panic!("bad selection input"),
+        }
+    }
+}
+
+pub async fn create(_params: Params, gw: &Gateway, cfg: &Config) -> Result<()> {
+    let mut create = CreateTask {
+        content: input_content("")?,
+        ..Default::default()
+    };
+
+    let mut due: Option<String> = None;
+    loop {
+        let mut items = vec![format!("{}", "Submit".bold().bright_blue())];
+        items.extend(
+            [
+                (Selection::TaskName, create.content.to_owned()),
+                (Selection::Due, due.clone().unwrap_or_default()),
+                (
+                    Selection::Description,
+                    create.description.clone().unwrap_or_default(),
+                ),
+                (
+                    Selection::Priority,
+                    create.priority.unwrap_or_default().to_string(),
+                ),
+            ]
+            .iter()
+            .map(|(name, content)| format!("{}: {}", name.bold(), content)),
+        );
+        let selection = match interactive::select("Edit task fields or submit", &items)? {
+            Some(0) => break,
+            Some(s) => Selection::from(s - 1),
+            None => return Err(eyre!("No selection made")),
+        };
+        match selection {
+            Selection::TaskName => create.content = input_content(&create.content)?,
+            Selection::Due => due = input_optional("Due", due)?,
+            Selection::Description => {
+                create.description = input_optional("Description", create.description)?
+            }
+            Selection::Priority => create.priority = input_priority()?,
+        }
+    }
+    if let Some(due) = due {
+        create.due = Some(TaskDue::String(due));
+    }
+    create_task(create, None, None, &[], gw, cfg).await
+}
+
+fn input_content(content: &str) -> Result<String> {
     let mut input = dialoguer::Input::new();
     input
-        .with_prompt("Task name")
+        .with_prompt("Task Name")
         .allow_empty(false)
         .validate_with(|input: &String| -> Result<(), &str> {
             if !input.is_empty() {
@@ -26,41 +106,31 @@ pub async fn create(params: Params, gw: &Gateway, cfg: &Config) -> Result<()> {
                 Err("empty task description")
             }
         });
-    create.content = input.interact_text().wrap_err("No input made")?;
-    let mut due: Option<String> = None;
-
-    let items = vec![
-        format!("{}", "Submit".bold().bright_blue()),
-        format!("{}: {}", "Task Name".bold(), create.content),
-        format!(
-            "{}: {}",
-            "Due".bold(),
-            due.as_ref().unwrap_or(&"".to_owned())
-        ),
-        format!(
-            "{}: {}",
-            "Description".bold(),
-            create.description.unwrap_or_default()
-        ),
-        format!(
-            "{}: {}",
-            "Priority".bold(),
-            create.priority.unwrap_or(Priority::Normal)
-        ),
-    ];
-    let selection = interactive::select("Edit task fields or submit", &items)?;
-    //
-    // let mut create = CreateTask {
-    //     content: params.name,
-    //     description: params.desc,
-    //     priority: params.priority.map(|p| p.into()),
-    //     project_id: project.map(|p| p.id),
-    //     section_id: section.map(|s| s.id),
-    //     label_ids: labels.iter().map(|l| l.id).collect(),
-    //     ..Default::default()
-    // };
-    if let Some(due) = due {
-        create.due = Some(TaskDue::String(due));
+    if !content.is_empty() {
+        input.with_initial_text(content.to_owned());
     }
-    Ok(())
+    input.interact_text().wrap_err("No input made")
+}
+
+fn input_optional(prompt: &str, default: Option<String>) -> Result<Option<String>> {
+    let mut input = dialoguer::Input::<'_, String>::new();
+    input.with_prompt(prompt).allow_empty(true);
+    if let Some(d) = default {
+        input.with_initial_text(d);
+    }
+    match input.interact_text().wrap_err("No input made")?.as_str() {
+        "" => Ok(None),
+        s => Ok(Some(s.to_owned())),
+    }
+}
+
+fn input_priority() -> Result<Option<Priority>> {
+    let items = [
+        Priority::Normal,
+        Priority::High,
+        Priority::VeryHigh,
+        Priority::Urgent,
+    ];
+    let selection = interactive::select("Priority", &items)?;
+    Ok(selection.map(|s| items[s]))
 }

--- a/src/tasks/create.rs
+++ b/src/tasks/create.rs
@@ -1,0 +1,56 @@
+use color_eyre::{eyre::WrapErr, Result};
+
+use crate::{
+    api::rest::{CreateTask, Gateway},
+    config::Config,
+};
+
+#[derive(clap::Parser, Debug)]
+pub struct Params {}
+
+pub async fn create(params: Params, gw: &Gateway, cfg: &Config) -> Result<()> {
+    let (projects, sections, labels) = tokio::try_join!(gw.projects(), gw.sections(), gw.labels())?;
+
+    let mut create = CreateTask::default();
+
+    let mut input = dialoguer::Input::new();
+    input
+        .with_prompt("Task name")
+        .allow_empty(false)
+        .validate_with(|input: &String| -> Result<(), &str> {
+            if !input.is_empty() {
+                Ok(())
+            } else {
+                Err("empty task description")
+            }
+        });
+    create.content = input.interact_text().wrap_err("No input made")?;
+
+    let items = vec![
+        "Task Name",
+        "Description",
+        "Priority",
+        "Project/Section",
+        "Labels",
+        "Done",
+    ];
+    let selection = dialoguer::Select::new()
+        .items(&items)
+        .default(items.len() - 1)
+        .interact()?;
+    println!("Selected item {:?}", selection);
+    //
+    // let mut create = CreateTask {
+    //     content: params.name,
+    //     description: params.desc,
+    //     priority: params.priority.map(|p| p.into()),
+    //     project_id: project.map(|p| p.id),
+    //     section_id: section.map(|s| s.id),
+    //     label_ids: labels.iter().map(|l| l.id).collect(),
+    //     ..Default::default()
+    // };
+    // if let Some(due) = params.due {
+    //     create.due = Some(TaskDue::String(due));
+    // }
+    Ok(())
+}

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -2,6 +2,7 @@
 pub mod add;
 pub mod close;
 pub mod comment;
+pub mod create;
 pub mod edit;
 mod filter;
 pub mod list;


### PR DESCRIPTION
This implements a first pass of the interactive task creation menu. Using `doist A` it's now possible to start creating a task fully interactively. Will expand this a bit later to allow adding labels and projects/sections.
