### PR TITLE
Make list the default when passing projects with argument

### DIFF
--- a/src/bin/doist.rs
+++ b/src/bin/doist.rs
@@ -1,10 +1,10 @@
 use clap::Parser;
 use color_eyre::Result;
-use doist::Args;
+use doist::Arguments;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     color_eyre::install()?;
-    let args = Args::parse();
+    let args = Arguments::parse();
     args.exec().await
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,4 +20,4 @@ mod sections;
 mod tasks;
 
 #[doc(hidden)]
-pub use command::Args;
+pub use command::Arguments;


### PR DESCRIPTION
This makes the API a tad bit easier to use. Will do the same with all other
listables.
