### PR TITLE
Enable fixtures for reading all endpoints

### DIFF
--- a/vhs/fixtures_server.py
+++ b/vhs/fixtures_server.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+import json
 import http.server
 import socketserver
 
@@ -6,25 +7,48 @@ PORT = 3000
 
 PREFIX = "../tests/commands/fixtures/"
 
-url_map = {
-    # TODO: do specific task ids etc
-    "/rest/v2/tasks": "tasks.json",
-    "/rest/v2/labels": "labels.json",
-    "/rest/v2/projects": "projects.json",
-    "/rest/v2/sections": "sections.json",
-}
-url_map = {k: open(PREFIX+v).read() for k, v in url_map.items()}
+def json_read(filename):
+    with open(PREFIX+filename, 'r') as f:
+        return json.load(f)
 
+tasks = json_read("tasks.json")
+tasks_partial = json_read("tasks_partial.json")
+labels = json_read("labels.json")
+projects = json_read("projects.json")
+sections = json_read("sections.json")
+
+url_map = {
+    "/rest/v2/tasks": {
+        "/": tasks,
+        "?filter=%28today+%7C+overdue%29": tasks_partial,
+    },
+    "/rest/v2/labels": {
+        "/": labels,
+    },
+    "/rest/v2/projects": {
+        "/": projects,
+    },
+    "/rest/v2/sections": {
+        "/": sections,
+    },
+}
+
+for k, v in url_map.items():
+    items = v["/"]
+    for item in items:
+        v["/"+item["id"]] = item
 
 class HTTPHandler(http.server.BaseHTTPRequestHandler):
     def do_GET(self):
         print("GET", self.path)
         for k, v in url_map.items():
             if self.path.startswith(k):
+                suffix = self.path[len(k):]
+                suffix = "/" if suffix == "" else suffix
                 self.send_response(200)
                 self.send_header("Content-Type", "application/json")
                 self.end_headers()
-                self.wfile.write(v.encode())
+                self.wfile.write(json.dumps(v[suffix]).encode())
                 return
         self.send_response(404)
         self.end_headers()

--- a/vhs/generate_vhs.sh
+++ b/vhs/generate_vhs.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 # All tape files are processed with VHS (https://github.com/charmbracelet/vhs) 
 # into gifs
-# TODO: spin up fake doist server for vhs generation
+./fixtures_server.py & server=$!
 vhs intro.tape
+kill "$server"

--- a/vhs/intro.tape
+++ b/vhs/intro.tape
@@ -1,10 +1,15 @@
 Output doist.gif
 # Require doist
-Set Theme {"name":"Monokai Vivid","black":"#121212","red":"#fa2934","green":"#98e123","yellow":"#fff30a","blue":"#0443ff","magenta":"#f800f8","cyan":"#01b6ed","white":"#ffffff","brightBlack":"#838383","brightRed":"#f6669d","brightGreen":"#b1e05f","brightYellow":"#fff26d","brightBlue":"#0443ff","brightMagenta":"#f200f6","brightCyan":"#51ceff","brightWhite":"#ffffff","background":"#121212","foreground":"#f9f9f9"}
-# Set Shell zsh
+Set Theme "Monokai Pro"
+Set Shell bash
 Set FontSize 32
 Set Width 1200
 Set Height 600
+
+Hide
+Type 'alias doist="./run_doist_fixtures.sh"'
+Enter
+Show
 
 Type "doist add 'do the laundry' -d tomorrow"
 Sleep 500ms

--- a/vhs/run_doist_fixtures.sh
+++ b/vhs/run_doist_fixtures.sh
@@ -1,9 +1,10 @@
 #!/bin/sh
+set -e
+
 dir=$(mktemp -d)
 cat >> "$dir/config.toml" << EOF
 token = "AUTH_KEY"
 url = "http://localhost:3000"
 override_time = "$(cat ../tests/commands/fixtures/fetch_time)"
 EOF
-cargo run -- --config_prefix="$dir"
-
+cargo run --quiet -- --config_prefix="$dir" "$@"


### PR DESCRIPTION
While not complete yet, this fully enables at least read endpoints to be read
with the fixtures provided by the tests. VHS can already start generating some
gifs from that. Before this is completed, will still need adding tasks (at
least) and write a new VHS tape.
