### PR TITLE
Fix flaky test

### DIFF
--- a/tests/commands/list.rs
+++ b/tests/commands/list.rs
@@ -36,7 +36,7 @@ async fn list() -> Result<()> {
 async fn expand() -> Result<()> {
     let cmd = Tool::init().await?;
 
-    mocks::mock_tasks(&cmd, 1).await;
+    mocks::mock_tasks_all(&cmd, 1).await;
     mocks::mock_tasks_partial(&cmd, 1).await;
     mocks::mock_labels(&cmd, 1).await;
     mocks::mock_projects(&cmd, 1).await;

--- a/tests/commands/mocks.rs
+++ b/tests/commands/mocks.rs
@@ -1,4 +1,4 @@
-use wiremock::{matchers, Mock, ResponseTemplate};
+use wiremock::{matchers, Mock, MockBuilder, ResponseTemplate};
 
 use crate::setup::Tool;
 
@@ -10,6 +10,19 @@ pub async fn mock_tasks(tool: &Tool, times: u64) {
         200,
         super::fixtures::TASKS,
         times,
+    )
+    .await
+}
+
+pub async fn mock_tasks_all(tool: &Tool, times: u64) {
+    mock_http_with_builder(
+        tool,
+        "GET",
+        "/rest/v2/tasks",
+        200,
+        super::fixtures::TASKS,
+        times,
+        |mb| mb.and(matchers::query_param("filter", "all")),
     )
     .await
 }
@@ -62,11 +75,23 @@ pub async fn mock_sections(tool: &Tool, times: u64) {
     .await
 }
 
-async fn mock_http(tool: &Tool, method: &str, path: &str, code: u16, body: &str, times: u64) {
-    Mock::given(matchers::method(method))
-        .and(matchers::path(path))
-        .respond_with(ResponseTemplate::new(code).set_body_raw(body, "application/json"))
+async fn mock_http_with_builder<F: Fn(MockBuilder) -> MockBuilder>(
+    tool: &Tool,
+    method: &str,
+    path: &str,
+    code: u16,
+    body: &str,
+    times: u64,
+    matchers: F,
+) {
+    let mut mb = Mock::given(matchers::method(method)).and(matchers::path(path));
+    mb = matchers(mb);
+    mb.respond_with(ResponseTemplate::new(code).set_body_raw(body, "application/json"))
         .up_to_n_times(times)
         .mount(&tool.mock)
         .await
+}
+
+async fn mock_http(tool: &Tool, method: &str, path: &str, code: u16, body: &str, times: u64) {
+    mock_http_with_builder(tool, method, path, code, body, times, |mb| mb).await
 }


### PR DESCRIPTION
List expand was messing up the orders in the mock calls. Constricted the mock
call properly now.
