### PR TITLE
Set default filter via configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,8 @@ doist view
 
 This accepts the same parameters as `doist list` for task selection.
 
+#### Configuration setup
+
 ### Disable colors
 
 If you're not a fan of emojis or colors, you can disable all doist-induced
@@ -197,6 +199,18 @@ colors by setting the environment variable `NO_COLOR`:
 ```bash
 NO_COLOR=1 doist
 ```
+
+### Custom default filter
+
+If you don't like the default filter of `(today | upcoming)`, you can set a
+different default filter in the `~/.config/doist/config.toml` like this:
+
+```toml
+default_filter="all"
+``````
+
+See the [Todoist article on filtering](https://todoist.com/help/articles/introduction-to-filters)
+for more information.
 
 ### Help
 

--- a/tests/commands/setup.rs
+++ b/tests/commands/setup.rs
@@ -23,7 +23,7 @@ impl Tool {
 
         let mock = MockServer::start().await;
         let mut cfg = Config::load_prefix(&tmp.path())?;
-        cfg.url = url::Url::parse(&mock.uri())?;
+        cfg.url = Some(url::Url::parse(&mock.uri())?);
         cfg.override_time = Some(super::fixtures::FETCH_TIME.trim().parse()?);
         cfg.save()?;
         Ok(Tool { tmp, cfg, mock })


### PR DESCRIPTION
This implements the ask in #95.

Now the filter will prioritize a passed-in argument, but on an empty argument,
it will fall back to the default filter, which is either declared in the config
file, or falling back even further to the in-code declared ``(today | upcoming)``
