### PR TITLE
fix: editing will parse response correctly

### DIFF
--- a/src/api/rest/gateway.rs
+++ b/src/api/rest/gateway.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{collections::HashMap, time::Duration};
 
 use chrono::Utc;
 use color_eyre::{
@@ -282,7 +282,7 @@ impl Gateway {
 
     /// Same as [`Gateway::post`], but doesn't require content to be set for the POST request.
     async fn post_empty<T: Serialize>(&self, path: &str, content: &T) -> Result<()> {
-        self.post::<_, String>(path, content).await?;
+        self.post::<_, Task>(path, content).await?;
         Ok(())
     }
 }

--- a/src/api/rest/gateway.rs
+++ b/src/api/rest/gateway.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, time::Duration};
+use std::time::Duration;
 
 use chrono::Utc;
 use color_eyre::{


### PR DESCRIPTION
This will make the editing commands properly work by parsing the response
correctly instead of failing to do so. The editing usually worked, but always
had the ugly error message popping out.

Fixes #99
