### PR TITLE
Fix label API updates

### DIFF
--- a/src/api/rest/label.rs
+++ b/src/api/rest/label.rs
@@ -60,7 +60,7 @@ pub struct CreateLabel {
     pub color: Option<String>,
     /// Mark as favorite or not.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub favorite: Option<bool>,
+    pub is_favorite: Option<bool>,
 }
 
 #[cfg(test)]

--- a/src/api/rest/project.rs
+++ b/src/api/rest/project.rs
@@ -101,6 +101,9 @@ pub struct CreateProject {
     /// Mark as favorite or not.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub favorite: Option<bool>,
+    /// Sets the view style of the project.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub view_style: Option<ViewStyle>,
 }
 
 #[cfg(test)]

--- a/src/api/rest/task.rs
+++ b/src/api/rest/task.rs
@@ -9,7 +9,7 @@ use reqwest::Url;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-use super::{LabelID, ProjectID, SectionID};
+use super::{ProjectID, SectionID};
 
 /// TaskID describes the unique ID of a [`Task`].
 pub type TaskID = String;
@@ -271,8 +271,8 @@ pub struct CreateTask {
     pub parent_id: Option<TaskID>,
     /// Sets the [`Task::order`] on the new [`Task`].
     pub order: Option<isize>,
-    /// Sets the [`Task::label_ids`] on the new [`Task`].
-    pub label_ids: Vec<LabelID>,
+    /// Sets the [`Task::labels`] on the new [`Task`].
+    pub labels: Vec<String>,
     /// Sets the [`Task::priority`] on the new [`Task`].
     pub priority: Option<Priority>,
     /// Sets the [`Task::due`] on the new [`Task`].
@@ -295,9 +295,9 @@ pub struct UpdateTask {
     /// Overwrites [`Task::description`] if set.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-    /// Overwrites [`Task::label_ids`] if set.
+    /// Overwrites [`Task::labels`] if set.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub label_ids: Option<Vec<LabelID>>,
+    pub labels: Option<Vec<String>>,
     /// Overwrites [`Task::priority`] if set.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub priority: Option<Priority>,

--- a/src/tasks/add.rs
+++ b/src/tasks/add.rs
@@ -49,21 +49,21 @@ pub async fn add(params: Params, gw: &Gateway, cfg: &Config) -> Result<()> {
         priority: params.priority.map(|p| p.into()),
         project_id: project.map(|p| p.id.clone()),
         section_id: section.map(|s| s.id.clone()),
-        label_ids: labels.iter().map(|l| l.id.clone()).collect(),
+        labels: labels.iter().map(|l| l.name.clone()).collect(),
         ..Default::default()
     };
     if let Some(due) = params.due {
         create.due = Some(TaskDue::String(due));
     }
-    let labels = if !create.label_ids.is_empty() {
+    let labels = if !create.labels.is_empty() {
         let mut labels: HashMap<_, _> = gw
             .labels()
             .await?
             .into_iter()
-            .map(|label| (label.id.clone(), label))
+            .map(|label| (label.name.clone(), label))
             .collect();
         create
-            .label_ids
+            .labels
             .iter()
             .filter_map(|l| labels.remove(l))
             .collect()

--- a/src/tasks/edit.rs
+++ b/src/tasks/edit.rs
@@ -43,21 +43,21 @@ impl Params {
 }
 
 pub async fn edit(params: Params, gw: &Gateway, cfg: &Config) -> Result<()> {
-    let label_ids = {
+    let labels = {
         let labels = params
             .labels
             .labels(&gw.labels().await?, labels::Selection::AllowEmpty)?;
         if labels.is_empty() {
             None
         } else {
-            Some(labels.into_iter().map(|l| l.id).collect())
+            Some(labels.into_iter().map(|l| l.name).collect())
         }
     };
     let mut update = UpdateTask {
         content: params.name,
         description: params.desc,
         priority: params.priority.map(|p| p.into()),
-        label_ids,
+        labels,
         ..Default::default()
     };
     if let Some(due) = params.due {


### PR DESCRIPTION
Todoist API has changed to accept labels directly instead of label IDs. This PR
changes all occurences of label IDs to label names.

I also snuck in one extra API change, but it should not impact anything.

Fixes #111.
