### PR TITLE
Add calendar project type.

### DIFF
--- a/src/api/rest/project.rs
+++ b/src/api/rest/project.rs
@@ -51,6 +51,8 @@ pub enum ViewStyle {
     List,
     /// Project as board view.
     Board,
+    /// Project as calendar view.
+    Calendar,
 }
 
 impl Default for ViewStyle {


### PR DESCRIPTION
Calendar type projects fail to parse without this.