### PR TITLE
Clean up error output for error messages.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,24 +351,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55146f5e46f237f7423d74111267d4597b59b0dad0ffaf7303bce9945d843ad5"
 dependencies = [
  "backtrace",
- "color-spantrace",
  "eyre",
  "indenter",
  "once_cell",
  "owo-colors 3.5.0",
- "tracing-error",
-]
-
-[[package]]
-name = "color-spantrace"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd6be1b2a7e382e2b98b43b2adcca6bb0e465af0bdd38123873ae61eb17a72c2"
-dependencies = [
- "once_cell",
- "owo-colors 3.5.0",
- "tracing-core",
- "tracing-error",
 ]
 
 [[package]]
@@ -2306,15 +2292,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sharded-slab"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
-dependencies = [
- "lazy_static",
-]
-
-[[package]]
 name = "shell-words"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2753,28 +2730,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
- "valuable",
-]
-
-[[package]]
-name = "tracing-error"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d686ec1c0f384b1277f097b2f279a2ecc11afe8c133c1aabf036a27cb4cd206e"
-dependencies = [
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.3.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
-dependencies = [
- "sharded-slab",
- "thread_local",
- "tracing-core",
 ]
 
 [[package]]
@@ -2882,12 +2837,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "valuable"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ name = "doist"
 chrono = { version = "0.4.39", features = ["serde"] }
 chrono-tz = { version = "0.10.0", features = ["serde"] }
 clap = { version = "4.5.23", features = ["derive", "wrap_help"] }
-color-eyre = "0.6.3"
+color-eyre = { version = "0.6.3", default-features = false }
 config = { version = "0.15.4", features = ["toml"] }
 dialoguer = { version = "0.11.0", features = ["fuzzy-select"] }
 dirs = "5.0.1"
@@ -43,7 +43,11 @@ thiserror = "2.0.9"
 tokio = { version = "1.42.0", features = ["macros", "rt", "rt-multi-thread"] }
 toml = "0.8.19"
 url = { version = "2.5.4", features = ["serde"] }
-uuid = { version = "1.11.0", features = ["v4", "fast-rng", "macro-diagnostics"] }
+uuid = { version = "1.11.0", features = [
+  "v4",
+  "fast-rng",
+  "macro-diagnostics",
+] }
 xdg = "2.5.2"
 
 [dev-dependencies]
@@ -66,4 +70,8 @@ ci = ["github"]
 # The installers to generate for each app
 installers = ["shell", "homebrew"]
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin", "aarch64-apple-darwin"]
+targets = [
+  "x86_64-unknown-linux-gnu",
+  "x86_64-apple-darwin",
+  "aarch64-apple-darwin",
+]

--- a/src/bin/doist.rs
+++ b/src/bin/doist.rs
@@ -4,7 +4,10 @@ use doist::Arguments;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    color_eyre::install()?;
+    color_eyre::config::HookBuilder::new()
+        .panic_section("consider reporting the bug at https://github.com/chaosteil/doist/issues")
+        .display_env_section(false)
+        .install()?;
     let args = Arguments::parse();
     args.exec().await
 }

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -286,7 +286,7 @@ mod test {
 
     type Selectable<'a> = (i32, &'a str);
 
-    impl<'a> FuzzSelect for Selectable<'a> {
+    impl FuzzSelect for Selectable<'_> {
         type ID = i32;
 
         fn id(&self) -> i32 {


### PR DESCRIPTION
This removes some of the default boilerplate error messages in the color-eyre result.

Additionally some cleanups in the various files affected.