### PR TITLE
Assign direct runners per build target

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -10,7 +10,13 @@ ci = "github"
 # The installers to generate for each app
 installers = ["shell", "powershell", "homebrew"]
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
+targets = [
+  "aarch64-apple-darwin",
+  "aarch64-unknown-linux-gnu",
+  "x86_64-apple-darwin",
+  "x86_64-unknown-linux-gnu",
+  "x86_64-pc-windows-msvc",
+]
 # A GitHub repo to push Homebrew formulas to
 tap = "chaosteil/homebrew-tap"
 # Publish jobs to run in CI
@@ -22,3 +28,12 @@ install-updater = false
 
 [dist.github-custom-runners]
 global = "ubuntu-22.04"
+
+[dist.github-custom-runners.aarch64-unknown-linux-gnu]
+global = "ubuntu-22.04"
+
+[dist.github-custom-runners.x86_64-unknown-linux-gnu]
+global = "ubuntu-22.04"
+
+[dist.github-custom-runners.x86_64-pc-windows-msvc]
+global = "windows-2022"


### PR DESCRIPTION
Previous iterations made windows/ubuntu fail. This hopefully fixes it.