### PR TITLE
Adjust wording for completing tasks

### DIFF
--- a/src/tasks/list.rs
+++ b/src/tasks/list.rs
@@ -201,7 +201,9 @@ fn list_tasks<'a>(tasks: &'a [Tree<Task>], state: &'a State) {
 
 #[derive(Display, FromRepr, VariantNames)]
 enum TaskOptions {
+    #[strum(serialize = "Close Task")]
     Close,
+    #[strum(serialize = "Complete Forever")]
     Complete,
     Edit,
     Quit,


### PR DESCRIPTION
This makes it a bit clearer what the individual things do in the task list. Closes #135 