### PR TITLE
fix(build): use windows-gnu instead of msvc for cross-compilation

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,7 +10,7 @@ builds:
       - x86_64-unknown-linux-gnu
       - x86_64-apple-darwin
       - aarch64-apple-darwin
-      - x86_64-pc-windows-msvc
+      - x86_64-pc-windows-gnu
 
 archives:
   - name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"


### PR DESCRIPTION
C'mon, let's fix #148 